### PR TITLE
Lotto prototype 1.3

### DIFF
--- a/src/TestLottery.hs
+++ b/src/TestLottery.hs
@@ -45,7 +45,7 @@ myTrace = do
     let pkh      = pubKeyHash $ walletPubKey $ Wallet 1
         jackpot'   = 10000000
         ticket'    = 2000000
-        deadline'  = slotToEndPOSIXTime def 500
+        deadline'  = slotToEndPOSIXTime def 50
 
         sp = StartParams
                 { spAdmin          = pkh
@@ -107,7 +107,7 @@ myTrace = do
             callEndpoint @"payout" h2 () 
             void $ Emulator.waitNSlots 5
             
-            
+            {-
             -- **** start the next lotto ****
             callEndpoint @"start" h1 sp
             void $ Emulator.waitNSlots 5
@@ -141,7 +141,7 @@ myTrace = do
             -- claim jackpot 
             callEndpoint @"payout" h3 () 
             void $ Emulator.waitNSlots 5
-            
+            -}
             
             
             

--- a/src/TestLottery.hs
+++ b/src/TestLottery.hs
@@ -44,8 +44,8 @@ myTrace = do
     
     let pkh      = pubKeyHash $ walletPubKey $ Wallet 1
         jackpot'   = 10000000
-        ticket'    = 2000000
-        deadline'  = slotToEndPOSIXTime def 50
+        ticket'    = 200000
+        deadline'  = slotToEndPOSIXTime def 100
 
         sp = StartParams
                 { spAdmin          = pkh
@@ -107,33 +107,29 @@ myTrace = do
             callEndpoint @"payout" h2 () 
             void $ Emulator.waitNSlots 5
             
-            {-
+            -- collect admin fees
+            callEndpoint @"collect" h1 ()
+            void $ Emulator.waitNSlots 5
+            
+            -- ****************************** 
             -- **** start the next lotto ****
             callEndpoint @"start" h1 sp
             void $ Emulator.waitNSlots 5
             
-            -- lotto play to buy lotto ticket with number 123
+            -- lotto player to buy lotto ticket with number 123
             callEndpoint @"buy" h2 123
             void $ Emulator.waitNSlots 5
             
-            -- callEndpoint @"buy" h2 456
-            -- void $ Emulator.waitNSlots 5
-            
+            -- lotto player to buy with ticket number 789
             callEndpoint @"buy" h3 789
             void $ Emulator.waitNSlots 5
             
-            -- try to close but not lotto admin            
-            --callEndpoint @"close" h2 123
-            --void $ Emulator.waitNSlots 5
             
-            -- lotto admin to close lotto with number 123
+            -- lotto admin to close lotto with number 789
             callEndpoint @"close" h1 789
             void $ Emulator.waitNSlots 5
          
-            -- lotto player to redeem ticket with winning number 123
-            --callEndpoint @"redeem" h2 ()
-            --void $ Emulator.waitNSlots 5
-            
+         
             -- lotto player try to redeem but does not have a winning ticket
             callEndpoint @"redeem" h3 () 
             void $ Emulator.waitNSlots 5
@@ -141,7 +137,14 @@ myTrace = do
             -- claim jackpot 
             callEndpoint @"payout" h3 () 
             void $ Emulator.waitNSlots 5
-            -}
+            
+            -- collect admin fees
+            callEndpoint @"collect" h1 ()
+            void $ Emulator.waitNSlots 5
+            
+            
+            
+            
             
             
             


### PR DESCRIPTION
    - added lotto admin fees to lotto datum
    - added 2% admin fee, 49% spit to current jackpot and 49% split to lotto treasury when buying a lotto ticket
    - fixed bug with incorrect ticket cost assignment in state machine datum
